### PR TITLE
Create bootstrapper only once per module

### DIFF
--- a/Schedules.API.Tests/Modules/RemindersTests.cs
+++ b/Schedules.API.Tests/Modules/RemindersTests.cs
@@ -10,7 +10,7 @@ namespace Schedules.API.Tests
     {
         Browser browser;
 
-        [SetUp]
+        [TestFixtureSetUp]
         public void SetUp()
         {
             browser = new Browser(new CustomBootstrapper());

--- a/Schedules.API.Tests/Modules/SchedulesTests.cs
+++ b/Schedules.API.Tests/Modules/SchedulesTests.cs
@@ -8,7 +8,7 @@ namespace Schedules.API.Tests
     {
         Browser browser;
 
-        [SetUp]
+        [TestFixtureSetUp]
         public void SetUp()
         {
             browser = new Browser(new CustomBootstrapper());

--- a/Schedules.API.Tests/Modules/StatusTests.cs
+++ b/Schedules.API.Tests/Modules/StatusTests.cs
@@ -10,7 +10,7 @@ namespace Schedules.API.Tests
 	{
     Browser browser;
 
-    [SetUp]
+    [TestFixtureSetUp]
     public void SetUp()
     {
       browser = new Browser(new CustomBootstrapper());


### PR DESCRIPTION
Creating the Bootstrapper is slow. This changes it from creating it once per test to just once per module (actually once per module test class). Currently all the tests could share the same Bootstrapper and shave off more time, but this change is just the quick win by swapping the NUnit attribute. It's noticeably faster.

This will fix #9.
