### PR TITLE
Fix case of package reference

### DIFF
--- a/Schedules.API.Tests/packages.config
+++ b/Schedules.API.Tests/packages.config
@@ -6,5 +6,5 @@
   <package id="Nancy.Authentication.Forms" version="0.23.1" targetFramework="net40" />
   <package id="Nancy.Testing" version="0.23.1" targetFramework="net40" />
   <package id="NUnit" version="2.6.3" targetFramework="net40" />
-  <package id="Simpler" version="3.0.0" targetFramework="net40" />
+  <package id="simpler" version="3.0.0" targetFramework="net40" />
 </packages>

--- a/Schedules.API/packages.config
+++ b/Schedules.API/packages.config
@@ -9,5 +9,5 @@
   <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net40" />
   <package id="Npgsql" version="2.1.3" targetFramework="net40" />
   <package id="NUnit" version="2.6.3" targetFramework="net40" />
-  <package id="Simpler" version="3.0.0" targetFramework="net40" />
+  <package id="simpler" version="3.0.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
This gets rid of the yellow warning thing in the package listings of Xamarin Studio.
