### PR TITLE
Buffer point less

### DIFF
--- a/Schedules.API/Tasks/Schedules/FetchStreetSweepings.cs
+++ b/Schedules.API/Tasks/Schedules/FetchStreetSweepings.cs
@@ -64,7 +64,7 @@ namespace Schedules.API
                                  FROM
                                         streetsweeping ss
                                  WHERE
-                                        ST_Intersects(ST_Buffer(ST_GeometryFromText(@Point, 4326), .001), ss.geom)";
+                                        ST_Intersects(ST_Buffer(ST_GeometryFromText(@Point, 4326), .0002), ss.geom)";
   }
 }
 


### PR DESCRIPTION
Previously, it was buffered to return streets nearby. Now it should only return streets the house is next to. There is still a possibility of multiple streets being returned.

This is just a first whack, it will probably need additional tweaks.
