### PR TITLE
Fix RemindOn bug

### DIFF
--- a/Schedules.API.Tests/Tasks/Reminders/CreateRemindersTests.cs
+++ b/Schedules.API.Tests/Tasks/Reminders/CreateRemindersTests.cs
@@ -14,8 +14,64 @@ namespace Schedules.API.Tests
 
     readonly DateTime julyOne = DateTime.Parse("07-01-2014");
 
-    [TestFixtureSetUp]
-    public void SetUp()
+
+    [Test]
+    public void SMSReminderShouldNotBeNull()
+    {
+      SetUpSms();
+      Assert.That(createSMSReminder.Out.Reminder, Is.Not.Null);
+    }
+
+    [Test]
+    public void SMSReminderShouldHaveAnId()
+    {
+      SetUpSms();
+      Assert.That(createSMSReminder.Out.Reminder.Id, Is.Not.EqualTo(0));
+    }
+
+    [Test]
+    public void SMSReminderShouldBeOfTypeSMS()
+    {
+      SetUpSms();
+      Assert.That(createSMSReminder.Out.Reminder.ReminderType.Name, Is.EqualTo("sms"));
+    }
+
+    [Test]
+    public void SMSReminderShouldHaveARemindOnDate()
+    {
+      SetUpSms();
+      Assert.That(createSMSReminder.Out.Reminder.RemindOn, Is.EqualTo(julyOne));
+    }
+
+        [Test]
+    public void EmailReminderShouldNotBeNull()
+    {
+      SetUpEmail();
+      Assert.That(createEmailReminder.Out.Reminder, Is.Not.Null);
+    }
+
+    [Test]
+    public void EmailReminderShouldHaveAnId()
+    {
+      SetUpEmail();
+      Assert.That(createEmailReminder.Out.Reminder.Id, Is.Not.EqualTo(0));
+    }
+
+    [Test]
+    public void EmailReminderShouldBeOfTypeEmail()
+    {
+      SetUpEmail();
+      Assert.That(createEmailReminder.Out.Reminder.ReminderType.Name, Is.EqualTo("email"));
+    }
+
+    [Test]
+    public void EmailReminderShouldHaveARemindOnDate()
+    {
+      SetUpEmail();
+      Assert.That(createEmailReminder.Out.Reminder.RemindOn, Is.EqualTo(julyOne));
+    }
+
+    void SetUpSms()
     {
       createSMSReminder = Task.New<CreateReminder>();
       createSMSReminder.In.ReminderTypeName = "sms";
@@ -27,9 +83,11 @@ namespace Schedules.API.Tests
         Address = "1234 address ave",
         CreatedAt = DateTime.Now
       };
-
       createSMSReminder.Execute();
+    }
 
+    void SetUpEmail()
+    {
       createEmailReminder = Task.New<CreateReminder>();
       createEmailReminder.In.ReminderTypeName = "email";
       createEmailReminder.In.Reminder = new Reminder {
@@ -40,44 +98,7 @@ namespace Schedules.API.Tests
         Address = "1234 address ave",
         CreatedAt = DateTime.Now
       };
-
       createEmailReminder.Execute();
-    }
-
-    [Test]
-    public void SMSReminderShouldNotBeNull()
-    {
-      Assert.That(createSMSReminder.Out.Reminder, Is.Not.Null);
-    }
-
-    [Test]
-    public void SMSReminderShouldHaveAnId()
-    {
-      Assert.That(createSMSReminder.Out.Reminder.Id, Is.Not.EqualTo(0));
-    }
-
-    [Test]
-    public void SMSReminderShouldHaveARemindOnDate()
-    {
-      Assert.That(createSMSReminder.Out.Reminder.RemindOn, Is.EqualTo(julyOne));
-    }
-
-    [Test]
-    public void EmailReminderShouldNotBeNull()
-    {
-      Assert.That(createEmailReminder.Out.Reminder, Is.Not.Null);
-    }
-
-    [Test]
-    public void EmailReminderShouldHaveAnId()
-    {
-      Assert.That(createEmailReminder.Out.Reminder.Id, Is.Not.EqualTo(0));
-    }
-
-    [Test]
-    public void EmailReminderShouldHaveARemindOnDate()
-    {
-      Assert.That(createEmailReminder.Out.Reminder.RemindOn, Is.EqualTo(julyOne));
     }
   }
 }

--- a/Schedules.API/Tasks/Reminders/CreateReminder.cs
+++ b/Schedules.API/Tasks/Reminders/CreateReminder.cs
@@ -38,6 +38,7 @@ namespace Schedules.API.Tasks
         }
         catch(Exception ex){
           Console.WriteLine (ex);
+          throw;
         }
       }
     }
@@ -45,13 +46,21 @@ namespace Schedules.API.Tasks
     const string sql = @"
       with insertReminder as (
         insert into Reminders(contact, message, remind_on, verified, address, reminder_type_id)
-        values(@Contact, @Message, @RemindOn, @Verified, @Address, @ReminderTypeId) returning *
+        values(@Contact, @Message, @RemindOn, @Verified, @Address, @ReminderTypeId)
+        returning *
       )
-      select * 
+      select
+        r.id,
+        r.contact,
+        r.message,
+        r.remind_on as RemindOn,
+        r.verified,
+        r.address,
+        r.reminder_type_id,
+        t.*
       from insertReminder r
       left join reminder_types t
         on t.id = r.reminder_type_id
-      ;
     ";
   }
 }


### PR DESCRIPTION
This fixes `CreateReminders` so that it inserts a value for `RemindOn` and returns it afterward. This also changes the logic of `CreateReminders` so that it doesn't swallow exceptions on database errors.
