### PR TITLE
Handle null street sweeping schedules

### DIFF
--- a/Schedules.API.Tests/Models/StreetSweepingTest.cs
+++ b/Schedules.API.Tests/Models/StreetSweepingTest.cs
@@ -1,0 +1,20 @@
+﻿using NUnit.Framework;
+using Schedules.API.Models;
+
+namespace Schedules.API.Tests
+{
+  [TestFixture]
+  public class StreetSweepingTest
+  {
+    [Test]
+    public void ShouldHandleNullSweepingData()
+    {
+      var ss = new StreetSweeping () {
+        FullName = "hello"
+      };
+
+      Assert.DoesNotThrow(() => ss.CreateSchedules());
+    }
+  }
+}
+

--- a/Schedules.API.Tests/Schedules.API.Tests.csproj
+++ b/Schedules.API.Tests/Schedules.API.Tests.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Tasks\Sending\PostRemindersEmailSendTests.cs" />
     <Compile Include="Modules\Sending\RemindersEmailSendTests.cs" />
     <Compile Include="Tasks\Reminders\FetchDueRemindersTests.cs" />
+    <Compile Include="Models\StreetSweepingTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
@@ -102,5 +103,6 @@
     <Folder Include="Tasks\Reminders\" />
     <Folder Include="Tasks\Sending\" />
     <Folder Include="Modules\Sending\" />
+    <Folder Include="Models\" />
   </ItemGroup>
 </Project>

--- a/Schedules.API/Models/StreetSweeping.cs
+++ b/Schedules.API/Models/StreetSweeping.cs
@@ -16,6 +16,8 @@ namespace Schedules.API.Models
 
     public StreetSweeping ()
     {
+      LeftSweep = string.Empty;
+      RightSweep = string.Empty;
     }
 
     /// <summary>


### PR DESCRIPTION
The new dataset is a subset of the original. I thought this meant less rows, but it actually nulls out the values for streets. The data changed and the code wasn't prepared.

This won't fix all failing tests from #56 as the basic problem is those tests are using invalid data. Pull request for that will follow shortly.
