### PR TITLE
Introduce Rake and Centroid

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source "http://rubygems.org"
+
 gem "travis"
+gem "centroid", "~> 1.1.0.pre.alpha3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     addressable (2.3.6)
     backports (3.6.0)
+    centroid (1.1.0.pre.alpha3)
     coderay (1.1.0)
     ethon (0.7.1)
       ffi (>= 1.3.0)
@@ -54,4 +55,5 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  centroid (~> 1.1.0.pre.alpha3)
   travis

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,12 @@
+require "centroid"
+
+Config = Centroid::Config.from_file "config.json"
+
+desc "Checks the local system"
+task :ok? do
+  Config.all.variables.each do |variable|
+    message = "#{variable} environment variable is missing."
+    raise message unless ENV.has_key? variable
+  end
+  puts "ok"
+end

--- a/config.json
+++ b/config.json
@@ -1,0 +1,12 @@
+{
+  "all": {
+    "variables": [
+      "ADMIN_USERNAME",
+      "ADMIN_PASSWORD",
+      "MANDRILL_API_KEY",
+      "MANDRILL_FROM_EMAIL",
+      "GEOSPATIAL_PROVIDER_NAME",
+      "GEOSPATIAL_CONNECTION_STRING"
+    ]
+  }
+}


### PR DESCRIPTION
Rake is for driving the project's automated tasks and [Centroid](https://github.com/ResourceDataInc/Centroid) helps manage configuration across languages and environments. Rake and Centroid are like teammates that somehow always show up on my team.

This also adds a rake task of `rake ok?` that currently just checks to see the local system has all the necessary environment variables. This could later run tests or whatever is necessary to help with getting a system to the status of OK.
