### PR TITLE
More Rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,53 +6,14 @@ Config = Centroid::Config.from_file "config.json"
 
 desc "Checks the local system"
 task :ok? do
-  Config.variables.each do |variable|
+  Config.all.variables.each do |variable|
     message = "#{variable} environment variable is missing."
     raise message unless ENV.has_key? variable
   end
   puts "ok"
 end
 
-desc "Send reminder emails"
-task :send do
-  token = authenticate
-  oneMinute = 60
-  options = {
-    headers: {
-      "User-Agent" => "test",
-      "Accept" => "application/json",
-      "Authorization" => "Token " + token
-    },
-    body: {
-      remindOn: Date.today,
-    },
-    timeout: oneMinute
-  }
-  response = HTTParty.post(Config.urls.sendEmailReminders, options)
-  puts response.code, response.body
-end
-
-desc "Create reminder"
-task :create_reminder do
-  puts "contact:"
-  contact = STDIN.gets.chomp
-
-  options = {
-    headers: {
-      "User-Agent" => "test"
-    },
-    body: {
-      contact: contact,
-      message: "This is a test message. Cross your fingers...",
-      remindOn: Date.today
-    }
-  }
-
-  response = HTTParty.post(Config.urls.createReminders, options)
-  puts response.code, response.body
-end
-
-def authenticate
+def authenticate(url)
   puts "username:"
   username = STDIN.gets.chomp
 
@@ -68,8 +29,76 @@ def authenticate
       password: password
     }
   }
+  response = HTTParty.post(url, options)
+end
 
-  response = HTTParty.post(Config.urls.authenticate, options)
-  data = JSON.parse(response.body)
-  return data["token"]
+def authenticate_task(url)
+  desc "Authenticate (#{url})"
+  task :authenticate do
+    puts url
+
+    response = authenticate url
+    puts response.code, response.body
+  end
+end
+
+def create_reminder_task(url)
+  desc "Create reminder (#{url})"
+  task :create_reminder do
+    puts url
+
+    puts "contact:"
+    contact = STDIN.gets.chomp
+
+    options = {
+      headers: {
+        "User-Agent" => "test"
+      },
+      body: {
+        contact: contact,
+        message: "This is a test message. Cross your fingers...",
+        remindOn: Date.today
+      }
+    }
+
+    response = HTTParty.post(url, options)
+    puts response.code, response.body
+  end
+end
+
+def send_email_reminders_task(auth_url, url)
+  desc "Send email reminders (#{url})"
+  task :send_email_reminders do
+    puts url
+
+    response = authenticate auth_url
+    data = JSON.parse(response.body)
+    token = data["token"]
+
+    oneMinute = 60
+    options = {
+      headers: {
+        "User-Agent" => "test",
+        "Accept" => "application/json",
+        "Authorization" => "Token " + token
+      },
+      body: {
+        remindOn: Date.today,
+      },
+      timeout: oneMinute
+    }
+    response = HTTParty.post(url, options)
+    puts response.code, response.body
+  end
+end
+
+Config.each do |environment|
+  next if environment == "all"
+  env_config = Config.for_environment environment
+
+  namespace environment do
+    authenticate_task env_config.urls.authenticate
+    create_reminder_task env_config.urls.createReminder
+    send_email_reminders_task env_config.urls.authenticate, env_config.urls.sendEmailReminders
+  end
 end

--- a/config.json
+++ b/config.json
@@ -1,15 +1,33 @@
 {
-  "urls": {
-    "authenticate": "http://localhost:8080/authenticate",
-    "createReminders": "http://localhost:8080/reminders/email",
-    "sendEmailReminders": "http://localhost:8080/reminders/email/send"
+  "local": {
+    "urls": {
+      "authenticate": "http://localhost:8080/authenticate",
+      "createReminder": "http://localhost:8080/reminders/email",
+      "sendEmailReminders": "http://localhost:8080/reminders/email/send"
+    }
   },
-  "variables": [
-    "ADMIN_USERNAME",
-    "ADMIN_PASSWORD",
-    "MANDRILL_API_KEY",
-    "MANDRILL_FROM_EMAIL",
-    "GEOSPATIAL_PROVIDER_NAME",
-    "GEOSPATIAL_CONNECTION_STRING"
-  ]
+  "staging": {
+    "urls": {
+      "authenticate": "http://staging-denver-now-api.herokuapp.com/authenticate",
+      "createReminder": "http://staging-denver-now-api.herokuapp.com/reminders/email",
+      "sendEmailReminders": "http://staging-denver-now-api.herokuapp.com/reminders/email/send"
+    }
+  },
+  "prod": {
+    "urls": {
+      "authenticate": "http://production-denver-now-api.herokuapp.com/authenticate",
+      "createReminder": "http://production-denver-now-api.herokuapp.com/reminders/email",
+      "sendEmailReminders": "http://production-denver-now-api.herokuapp.com/reminders/email/send"
+    }
+  },
+  "all": {
+    "variables": [
+      "ADMIN_USERNAME",
+      "ADMIN_PASSWORD",
+      "MANDRILL_API_KEY",
+      "MANDRILL_FROM_EMAIL",
+      "GEOSPATIAL_PROVIDER_NAME",
+      "GEOSPATIAL_CONNECTION_STRING"
+    ]
+  }
 }


### PR DESCRIPTION
Changes
- Break up the config into environments
- Add environment namespaces to the environment specific rake tasks
- Add a rake task for creating reminders
- Prompts the user for inputs on rake tasks that call API endpoints
