### PR TITLE
Add street side

### DIFF
--- a/Schedules.API/Tasks/Schedules/FetchStreetSweepings.cs
+++ b/Schedules.API/Tasks/Schedules/FetchStreetSweepings.cs
@@ -55,6 +55,7 @@ namespace Schedules.API.Tasks.Schedules
                                         jurisid as JurisdictionId,
                                         maintnce as Maintenance,
                                         addressqua as AddressQuadrant,
+                                        hundblkdir as StreetDirection,
                                         zipleft,
                                         zipright,
                                         oneway,


### PR DESCRIPTION
Does it away with street descriptions like _left side_ and _right side_. Uses directional descriptions instead, like _North_ or _East_.
