### PR TITLE
Throw error if environment variable doesn't exist

### DIFF
--- a/Schedules.API/Helpers/EnvironmentVariableHelper.cs
+++ b/Schedules.API/Helpers/EnvironmentVariableHelper.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Schedules.API.Helpers
+{
+  public static class EnvironmentVariableHelper
+  {
+    /// <summary>
+    /// Gets an environment variable. 
+    /// Throws<exception cref="Exception"></exception>if it doesn't exist.
+    /// </summary>
+    /// <returns>The environment variable.</returns>
+    /// <param name="key">Key.</param>
+    public static string GetEnvironmentVariable(string key)
+    {
+      var value = Environment.GetEnvironmentVariable(key);
+      if (String.IsNullOrEmpty(value)) throw new Exception (key + " environment variable not found.");
+      return value;
+    }
+  }
+}
+

--- a/Schedules.API/Modules/AuthenticateModule.cs
+++ b/Schedules.API/Modules/AuthenticateModule.cs
@@ -1,5 +1,4 @@
 ﻿using Nancy;
-using Nancy.Security;
 using Nancy.Authentication.Token;
 using Schedules.API.Models;
 using Nancy.ModelBinding;
@@ -9,13 +8,17 @@ namespace Schedules.API.Modules
 {
   public class AuthenticateModule : NancyModule
   {
+    private const string adminKey = "ADMIN_USERNAME";
+    private const string passwordKey = "ADMIN_PASSWORD";
+
     public AuthenticateModule(ITokenizer tokenizer)
     {
       Post["/authenticate"] = x => {
         var user = this.Bind<User>();
 
-        var username = Environment.GetEnvironmentVariable("ADMIN_USERNAME");
-        var password = Environment.GetEnvironmentVariable("ADMIN_PASSWORD");
+        var username = Environment.GetEnvironmentVariable(adminKey);
+        var password = Environment.GetEnvironmentVariable(passwordKey);
+
         if (String.IsNullOrEmpty(username) || String.IsNullOrEmpty(password)) return HttpStatusCode.Unauthorized;
         if (user.Username != username || user.Password != password) return HttpStatusCode.Unauthorized;
 

--- a/Schedules.API/Schedules.API.csproj
+++ b/Schedules.API/Schedules.API.csproj
@@ -173,6 +173,7 @@
     <Compile Include="Tasks\Sending\SendSMS.cs" />
     <Compile Include="Tasks\Sending\SendReminderBase.cs" />
     <Compile Include="Tasks\Sending\PostRemindersSend.cs" />
+    <Compile Include="Helpers\EnvironmentVariableHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Models\" />

--- a/Schedules.API/Tasks/Db.cs
+++ b/Schedules.API/Tasks/Db.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Data.Common;
-using System.Configuration;
+using Schedules.API.Helpers;
 
 namespace Schedules.API.Tasks
 {
@@ -12,8 +12,9 @@ namespace Schedules.API.Tasks
 
     public static DbConnection Connect() {
       // Reference: github.com/gregoryjscott/chic/TaskExtensions
-      var providerName = System.Environment.GetEnvironmentVariable (providerKey);
-      var connectionString = System.Environment.GetEnvironmentVariable (connectionKey);
+      var providerName = EnvironmentVariableHelper.GetEnvironmentVariable(providerKey);
+      var connectionString = EnvironmentVariableHelper.GetEnvironmentVariable(connectionKey);
+
       DbProviderFactory factory;
       try{
         factory = DbProviderFactories.GetFactory (providerName);

--- a/Schedules.API/Tasks/Sending/SendEmails.cs
+++ b/Schedules.API/Tasks/Sending/SendEmails.cs
@@ -1,20 +1,20 @@
-﻿using Simpler;
-using Schedules.API.Models;
+﻿using Schedules.API.Models;
 using Mandrill;
 using System.Collections.Generic;
 using System;
+using Schedules.API.Helpers;
 
 namespace Schedules.API.Tasks.Sending
 {
   public class SendEmails : SendReminderBase
   {
+    private const string mandrillAPIKey = "MANDRILL_API_KEY";
+    private const string fromEmailKey = "MANDRILL_FROM_EMAIL";
+
     public override void Execute ()
     {
-      var apiKey = Environment.GetEnvironmentVariable("MANDRILL_API_KEY");
-      if (String.IsNullOrEmpty(apiKey)) throw new Exception ("MANDRILL_API_KEY environment variable not found.");
-
-      var fromEmail = Environment.GetEnvironmentVariable("MANDRILL_FROM_EMAIL");
-      if (String.IsNullOrEmpty(fromEmail)) throw new Exception ("MANDRILL_FROM_EMAIL environment variable not found.");
+      var apiKey = EnvironmentVariableHelper.GetEnvironmentVariable(mandrillAPIKey);
+      var fromEmail = EnvironmentVariableHelper.GetEnvironmentVariable(fromEmailKey);
 
       var api = new MandrillApi (apiKey);
 

--- a/Schedules.API/Tasks/Sending/SendSMS.cs
+++ b/Schedules.API/Tasks/Sending/SendSMS.cs
@@ -1,17 +1,21 @@
 ﻿using System;
-using Simpler;
 using Schedules.API.Models;
 using Twilio;
+using Schedules.API.Helpers;
 
 namespace Schedules.API.Tasks.Sending
 {
   public class SendSMS: SendReminderBase
   {
+    private const string sidKey = "TWILIO_SID";
+    private const string tokenKey = "TWILIO_TOKEN";
+    private const string numberKey = "TWILIO_NUMBER";
+
     public override void Execute ()
     {
-      var sid = Environment.GetEnvironmentVariable ("TWILIO_SID");
-      var token = Environment.GetEnvironmentVariable ("TWILIO_TOKEN");
-      var number = Environment.GetEnvironmentVariable ("TWILIO_NUMBER");
+      var sid = EnvironmentVariableHelper.GetEnvironmentVariable(sidKey);
+      var token = EnvironmentVariableHelper.GetEnvironmentVariable(tokenKey);
+      var number = EnvironmentVariableHelper.GetEnvironmentVariable(numberKey);
 
       var client = new TwilioRestClient (sid, token);
 


### PR DESCRIPTION
Handling of environment variables was previously all over the place. This standardizes it:
- Puts string at top of file.
- Throws an error if environment variable doesn't exist
- Exception: Admin username/password throws a special exception and doesn't use the standard.
